### PR TITLE
Fix torch module import error of Sphinx

### DIFF
--- a/openml/extensions/pytorch/extension.py
+++ b/openml/extensions/pytorch/extension.py
@@ -88,7 +88,8 @@ class PytorchExtension(Extension):
         -------
         bool
         """
-        return isinstance(model, torch.nn.Module)
+        from torch.nn import Module
+        return isinstance(model, Module)
 
     ################################################################################################
     # Methods for flow serialization and de-serialization


### PR DESCRIPTION

**Summary:**
Added local import of torch.nn.Module into the can_handle_model() method of the pytorch extension, in order to fix Sphinx-related issue

**Changes:**
<!-- What are the changes made in this pull request? -->

- Add local import of nn.Module into can_handle_model()